### PR TITLE
[#46] feat : 이벤트 쿠폰 신청 및 발급 기능 구현

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/controller/PromotionEventController.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/controller/PromotionEventController.java
@@ -7,6 +7,7 @@ import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventCr
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindAllResponseDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindOneResponseDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventUpdateResponseDto;
+import com.sparta.popupstore.domain.promotionevent.service.CouponCreateResponseDto;
 import com.sparta.popupstore.domain.promotionevent.service.PromotionEventService;
 import com.sparta.popupstore.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,6 +55,14 @@ public class PromotionEventController {
         return ResponseEntity.ok(promotionEventService.findAllPromotionalEvents(page, size));
     }
 
+    @Operation(summary = "프로모션 이벤트 단건 조회")
+    @GetMapping("/promotionEvents/{promotionEventId}")
+    public ResponseEntity<PromotionEventFindOneResponseDto> findOnePromotionalEvent(
+            @PathVariable(name = "promotionEventId") Long promotionEventId
+    ){
+        return ResponseEntity.ok(promotionEventService.findOnePromotionEvent(promotionEventId));
+    }
+
     @Operation(summary = "프로모션 이벤트 수정")
     @Parameter(name = "title", description = "이벤트 제목")
     @Parameter(name = "description", description = "이벤트 설명")
@@ -80,11 +89,12 @@ public class PromotionEventController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @Operation(summary = "프로모션 이벤트 단건 조회")
-    @GetMapping("/promotionEvents/{promotionEventId}")
-    public ResponseEntity<PromotionEventFindOneResponseDto> findOnePromotionalEvent(
-            @PathVariable(name = "promotionEventId") Long promotionEventId
+    @Operation(summary = "프로모션 이벤트 쿠폰 신청 및 발급")
+    @PostMapping("/promotionEvents/{promotionEventId}/coupons")
+    public ResponseEntity<CouponCreateResponseDto> couponApplyAndIssuance(
+            @PathVariable(name = "promotionEventId") Long promotionEventId,
+            @AuthUser User user
     ){
-        return ResponseEntity.ok(promotionEventService.findOnePromotionEvent(promotionEventId));
+        return ResponseEntity.ok(promotionEventService.couponApplyAndIssuance(promotionEventId, user));
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/Coupon.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/Coupon.java
@@ -40,7 +40,8 @@ public class Coupon {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Coupon(User user, PromotionEvent promotionEvent, String serialNumber) {
+    public Coupon(User user, PromotionEvent promotionEvent, String serialNumber, Long couponId) {
+        this.id = couponId;
         this.user = user;
         this.promotionEvent = promotionEvent;
         this.serialNumber = serialNumber;

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/Coupon.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/Coupon.java
@@ -3,6 +3,7 @@ package com.sparta.popupstore.domain.promotionevent.entity;
 import com.sparta.popupstore.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -20,16 +21,16 @@ public class Coupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private PromotionEvent promotionEvent;
 
     @Column
-    private String serial_number;
+    private String serialNumber;
 
     @CreatedDate
     @Column(updatable = false)
@@ -37,4 +38,11 @@ public class Coupon {
 
     @Column
     private LocalDateTime deletedAt;
+
+    @Builder
+    public Coupon(User user, PromotionEvent promotionEvent, String serialNumber) {
+        this.user = user;
+        this.promotionEvent = promotionEvent;
+        this.serialNumber = serialNumber;
+    }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/PromotionEvent.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/PromotionEvent.java
@@ -74,4 +74,8 @@ public class PromotionEvent extends BaseEntity {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
     }
+
+    public void couponGetCountUp() {
+        this.couponGetCount++;
+    }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
@@ -3,7 +3,6 @@ package com.sparta.popupstore.domain.promotionevent.repository;
 
 import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -12,8 +11,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     List<Coupon> findByUserId(Long userId);
 
-    @Query("select exists (select 1 from Coupon c where c.promotionEvent.id = :promotionEventId and c.user.id = :userId)")
-    boolean existsByUserIdAndPromotionEventId(
+    boolean existsByPromotionEventIdAndUserId(
             @Param("promotionEventId") Long promotionEventId,
-            @Param("userId") Long userId);
+            @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
@@ -3,10 +3,17 @@ package com.sparta.popupstore.domain.promotionevent.repository;
 
 import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     List<Coupon> findByUserId(Long userId);
+
+    @Query("select exists (select 1 from Coupon c where c.promotionEvent.id = :promotionEventId and c.user.id = :userId)")
+    boolean existsByUserIdAndPromotionEventId(
+            @Param("promotionEventId") Long promotionEventId,
+            @Param("userId") Long userId);
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -21,7 +21,8 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query("select p from PromotionEvent p where p.id = :promotionEventId and p.deletedAt is null")
     Optional<PromotionEvent> findByPromotionEventId(@Param("promotionEventId") Long promotionEventId);
 
-    @Modifying
-    @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
-    void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
+//    추후에 스케쥴러에서 쓰일 수도 있을 것 같아서 일단 주석으로 냅두겠습니당
+//    @Modifying
+//    @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
+//    void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -20,4 +20,8 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
 
     @Query("select p from PromotionEvent p where p.id = :promotionEventId and p.deletedAt is null")
     Optional<PromotionEvent> findByPromotionEventId(@Param("promotionEventId") Long promotionEventId);
+
+    @Modifying
+    @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
+    void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponCreateResponseDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponCreateResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.popupstore.domain.promotionevent.service;
+
+import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
+import lombok.Getter;
+
+@Getter
+public class CouponCreateResponseDto {
+    private final Long id;
+    private final String serialNumber;
+    private final String userName;
+    private final String popupStoreName;
+
+    public CouponCreateResponseDto(Coupon coupon) {
+        this.id = coupon.getId();
+        this.serialNumber = coupon.getSerialNumber();
+        this.userName = coupon.getUser().getName();
+        this.popupStoreName = coupon.getPromotionEvent()
+                .getPopupStore() != null ? coupon.getPromotionEvent().getPopupStore().getName() : null;
+    }
+}

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
@@ -16,7 +16,7 @@ public class CouponService {
     private final CouponRepository couponRepository;
 
     public Coupon createCoupon(PromotionEvent promotionEvent, User user) {
-        if (couponRepository.existsByUserIdAndPromotionEventId(promotionEvent.getId(), user.getId())) {
+        if (couponRepository.existsByPromotionEventIdAndUserId(promotionEvent.getId(), user.getId())) {
             throw new IllegalArgumentException("이미 발급 받으신 쿠폰입니다.");
         }
         String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
@@ -1,0 +1,30 @@
+package com.sparta.popupstore.domain.promotionevent.service;
+
+import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
+import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
+import com.sparta.popupstore.domain.promotionevent.repository.CouponRepository;
+import com.sparta.popupstore.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public Coupon createCoupon(PromotionEvent promotionEvent, User user) {
+        if (couponRepository.existsByUserIdAndPromotionEventId(promotionEvent.getId(), user.getId())) {
+            throw new IllegalArgumentException("이미 발급 받으신 쿠폰입니다.");
+        }
+        String uuid = UUID.randomUUID().toString();
+        Coupon coupon = Coupon.builder()
+                .user(user)
+                .promotionEvent(promotionEvent)
+                .serialNumber(uuid)
+                .build();
+        return couponRepository.save(coupon);
+    }
+}

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -76,7 +76,7 @@ public class PromotionEventService {
             throw new IllegalArgumentException("쿠폰이 모두 소진되었습니다.");
         }
         Coupon coupon = couponService.createCoupon(promotionEvent, user);
-        promotionEventRepository.couponGetCountUp(promotionEventId);
+        promotionEvent.couponGetCountUp();
         return new CouponCreateResponseDto(coupon);
     }
 

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -7,8 +7,10 @@ import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventCr
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindAllResponseDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindOneResponseDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventUpdateResponseDto;
+import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
 import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
 import com.sparta.popupstore.domain.promotionevent.repository.PromotionEventRepository;
+import com.sparta.popupstore.domain.user.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,6 +24,7 @@ public class PromotionEventService {
 
     private final PromotionEventRepository promotionEventRepository;
     private final PopupStoreRepository popupStoreRepository;
+    private final CouponService couponService;
 
     public PromotionEventCreateResponseDto createEvent(
             PromotionEventCreateRequestDto promotionEventCreateRequestDto,
@@ -39,9 +42,16 @@ public class PromotionEventService {
         return promotionEventRepository.findAllPromotionalEvents(pageable).map(PromotionEventFindAllResponseDto::new);
     }
 
+    public PromotionEventFindOneResponseDto findOnePromotionEvent(Long promotionEventId) {
+        return new PromotionEventFindOneResponseDto(this.getPromotionEvent(promotionEventId));
+    }
+
     @Transactional
-    public PromotionEventUpdateResponseDto updatePromotionEvent(PromotionEventUpdateRequestDto promotionEventUpdateRequestDto, Long promotionEventId) {
-        PromotionEvent promotionEvent = promotionEventRepository.findByPromotionEventId(promotionEventId).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 이벤트입니다."));
+    public PromotionEventUpdateResponseDto updatePromotionEvent(
+            PromotionEventUpdateRequestDto promotionEventUpdateRequestDto
+            , Long promotionEventId
+    ) {
+        PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
         promotionEvent.updatePromotionEvent(
                 promotionEventUpdateRequestDto.getTitle(),
                 promotionEventUpdateRequestDto.getDescription(),
@@ -55,14 +65,25 @@ public class PromotionEventService {
 
     @Transactional
     public void deletePromotionEvent(Long promotionEventId) {
-        promotionEventRepository.findByPromotionEventId(promotionEventId).orElseThrow(()-> new IllegalArgumentException("존재하지 않거나 이미 삭제된 이벤트입니다."));
+        this.getPromotionEvent(promotionEventId);
         promotionEventRepository.deletePromotionEvent(promotionEventId);
     }
 
-    public PromotionEventFindOneResponseDto findOnePromotionEvent(Long promotionEventId) {
-        return new PromotionEventFindOneResponseDto(
-                promotionEventRepository.findByPromotionEventId(promotionEventId)
-                        .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 이벤트입니다."))
-        );
+    @Transactional
+    public CouponCreateResponseDto couponApplyAndIssuance(Long promotionEventId, User user) {
+        PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
+        if(promotionEvent.getCouponGetCount() == promotionEvent.getTotalCount()){
+            throw new IllegalArgumentException("쿠폰이 모두 소진되었습니다.");
+        }
+        Coupon coupon = couponService.createCoupon(promotionEvent, user);
+        promotionEventRepository.couponGetCountUp(promotionEventId);
+        return new CouponCreateResponseDto(coupon);
+    }
+
+    private PromotionEvent getPromotionEvent(Long promotionEventId) {
+        return promotionEventRepository.findByPromotionEventId(promotionEventId)
+                .orElseThrow(
+                        ()-> new IllegalArgumentException("존재하지 않거나 종료된 이벤트입니다.")
+                );
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/user/dto/response/UserMyCouponsResponseDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/user/dto/response/UserMyCouponsResponseDto.java
@@ -8,9 +8,8 @@ import lombok.Getter;
 public class UserMyCouponsResponseDto {
     private final Long id;
     private final String serialNumber;
-
     public UserMyCouponsResponseDto(Coupon coupon) {
         this.id = coupon.getId();
-        this.serialNumber = coupon.getSerial_number();
+        this.serialNumber = coupon.getSerialNumber();
     }
 }


### PR DESCRIPTION
발급 해 주기 전에 쿠폰 총 갯수와 현재 쿠폰 발급 수량을 비교해서 총 갯수보다 작을 경우에만 발급해주고 같은 유저가 같은 이벤트 쿠폰 발급 못하게 막았습니다. serial_number 변수명 -> serialNumber 로 수정

```json
{
    "id": 5,
    "serialNumber": "cb638ac8-97ab-48d2-8724-226443b11fe7",
    "userName": "승승",
    "popupStoreName": "하츄핑 팝스토어"
}
```