### PR TITLE
[#46] fix : 쿠폰 만료일자 날짜 형식 수정

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
@@ -12,10 +12,13 @@ public enum ErrorCode {
     // popupStore error
 
     // event error
-
+    PROMOTION_EVENT_NOT(403, "이벤트를 다시 한번 확인해주세요."),
+    PROMOTION_EVENT_ALREADY(400, "이미 시작한 이벤트는 수정 및 삭제 할 수 없습니다."),
     // review error
 
     // coupon error
+    COUPON_SOLD_OUT(400,"쿠폰이 모두 소진되었습니다."),
+    COUPON_DUPLICATE_ISSUANCE(400, "이미 발급 받으신 쿠폰입니다."),
 
     ;
     private final int status;

--- a/src/main/java/com/sparta/popupstore/domain/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/popupstore/domain/common/exception/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> validationException(MethodArgumentNotValidException e) {
         Map<String, String> errorMap = new HashMap<>();
+        // 테스트해봤는데 없어도 잘 나오네요 혹시 모르니까 다른분들도 테스트 해보시는게 좋을 거 같아욤
         //e.getBindingResult().getGlobalErrors().forEach(error -> errorMap.put(error.getObjectName(), error.getDefaultMessage()));
         e.getBindingResult().getFieldErrors().forEach(error -> errorMap.put(error.getField(), error.getDefaultMessage()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/response/CouponCreateResponseDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/response/CouponCreateResponseDto.java
@@ -3,22 +3,17 @@ package com.sparta.popupstore.domain.promotionevent.dto.response;
 import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 public class CouponCreateResponseDto {
     private final Long id;
     private final String serialNumber;
-    private final String userName;
-    private final String popupStoreName;
-    private final LocalDateTime couponExpirationPeriod;
+    private final LocalDate couponExpirationPeriod;
 
     public CouponCreateResponseDto(Coupon coupon) {
         this.id = coupon.getId();
         this.serialNumber = coupon.getSerialNumber();
-        this.userName = coupon.getUser().getName();
-        this.popupStoreName = coupon.getPromotionEvent()
-                .getPopupStore() != null ? coupon.getPromotionEvent().getPopupStore().getName() : null;
         this.couponExpirationPeriod = coupon.getCouponExpirationPeriod();
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/Coupon.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/Coupon.java
@@ -1,6 +1,5 @@
 package com.sparta.popupstore.domain.promotionevent.entity;
 
-import com.sparta.popupstore.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -21,17 +21,13 @@ public class Coupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private PromotionEvent promotionEvent;
+    private Long userId;
+    private Long promotionEventId;
+    private Long popupStoreId;
 
     private String serialNumber;
 
-    private LocalDateTime couponExpirationPeriod;
+    private LocalDate couponExpirationPeriod;
 
     @CreatedDate
     @Column(updatable = false)
@@ -40,11 +36,12 @@ public class Coupon {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Coupon(User user, PromotionEvent promotionEvent, String serialNumber, Long couponId) {
+    public Coupon(Long userId, PromotionEvent promotionEvent, String serialNumber, Long couponId) {
         this.id = couponId;
-        this.user = user;
-        this.promotionEvent = promotionEvent;
+        this.userId = userId;
+        this.promotionEventId = promotionEvent.getId();
+        this.popupStoreId = promotionEvent.getPopupStore() != null ? promotionEvent.getPopupStore().getId() : null;
         this.serialNumber = serialNumber;
-        this.couponExpirationPeriod = LocalDateTime.now().plusDays(promotionEvent.getCouponExpirationPeriod());
+        this.couponExpirationPeriod = LocalDate.now().plusDays(promotionEvent.getCouponExpirationPeriod());
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
@@ -1,5 +1,7 @@
 package com.sparta.popupstore.domain.promotionevent.service;
 
+import com.sparta.popupstore.domain.common.exception.CustomApiException;
+import com.sparta.popupstore.domain.common.exception.ErrorCode;
 import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
 import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
 import com.sparta.popupstore.domain.promotionevent.repository.CouponRepository;
@@ -17,11 +19,11 @@ public class CouponService {
 
     public Coupon createCoupon(PromotionEvent promotionEvent, User user) {
         if (couponRepository.existsByPromotionEventIdAndUserId(promotionEvent.getId(), user.getId())) {
-            throw new IllegalArgumentException("이미 발급 받으신 쿠폰입니다.");
+            throw new CustomApiException(ErrorCode.COUPON_DUPLICATE_ISSUANCE);
         }
         String uuid = UUID.randomUUID().toString();
         Coupon coupon = Coupon.builder()
-                .user(user)
+                .userId(user.getId())
                 .promotionEvent(promotionEvent)
                 .serialNumber(uuid)
                 .build();

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -1,5 +1,7 @@
 package com.sparta.popupstore.domain.promotionevent.service;
 
+import com.sparta.popupstore.domain.common.exception.CustomApiException;
+import com.sparta.popupstore.domain.common.exception.ErrorCode;
 import com.sparta.popupstore.domain.popupstore.repository.PopupStoreRepository;
 import com.sparta.popupstore.domain.promotionevent.dto.request.PromotionEventCreateRequestDto;
 import com.sparta.popupstore.domain.promotionevent.dto.request.PromotionEventUpdateRequestDto;
@@ -52,7 +54,7 @@ public class PromotionEventService {
     ) {
         PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
         if(promotionEvent.getStartDateTime().isBefore(LocalDateTime.now())){
-            throw new IllegalArgumentException("이미 시작한 이벤트는 수정할 수 없습니다.");
+            throw new CustomApiException(ErrorCode.PROMOTION_EVENT_ALREADY);
         }
         promotionEvent.updatePromotionEvent(
                 promotionEventUpdateRequestDto.getTitle(),
@@ -70,7 +72,7 @@ public class PromotionEventService {
     public void deletePromotionEvent(Long promotionEventId) {
         PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
         if(promotionEvent.getStartDateTime().isBefore(LocalDateTime.now())){
-            throw new IllegalArgumentException("이미 시작한 이벤트는 삭제할 수 없습니다.");
+            throw new CustomApiException(ErrorCode.PROMOTION_EVENT_ALREADY);
         }
         promotionEventRepository.deletePromotionEvent(promotionEventId);
     }
@@ -79,7 +81,7 @@ public class PromotionEventService {
     public CouponCreateResponseDto couponApplyAndIssuance(Long promotionEventId, User user) {
         PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
         if(promotionEvent.getCouponGetCount() == promotionEvent.getTotalCount()){
-            throw new IllegalArgumentException("쿠폰이 모두 소진되었습니다.");
+            throw new CustomApiException(ErrorCode.COUPON_SOLD_OUT);
         }
         Coupon coupon = couponService.createCoupon(promotionEvent, user);
         promotionEvent.couponGetCountUp();
@@ -89,7 +91,7 @@ public class PromotionEventService {
     private PromotionEvent getPromotionEvent(Long promotionEventId) {
         return promotionEventRepository.findByPromotionEventId(promotionEventId)
                 .orElseThrow(
-                        ()-> new IllegalArgumentException("존재하지 않거나 종료된 이벤트입니다.")
+                        ()-> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT)
                 );
     }
 }


### PR DESCRIPTION
만료일자 형식 수정 및 쿠폰 엔티티에 유저와 프로모션 이벤트 연관관계 해제 후
Long 타입으로 User, PromotionEvent, PopupStoreId 컬럼 생성 CouponService 와 PromotionEventService 에 GlobalExceptionHandler 적용

```json
{
    "id": 3,
    "serialNumber": "33489ac0-ecaf-488b-bd09-bd5e4765c224",
    "couponExpirationPeriod": "2024-12-26"
}
```

```json
{
    "msg": "이미 발급 받으신 쿠폰입니다.",
    "status": 400
}
```