### PR TITLE
[#114] fix : 이벤트 삭제 요청 시 이미지가 있다면 s3에서도 삭제되도록 수정

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     POPUP_STORE_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 팝업스토어가 없습니다."),
     POPUP_STORE_NOT_RESERVATION(HttpStatus.INTERNAL_SERVER_ERROR,"예약한 팝업스토어가 아닙니다."),
     // event error
-    PROMOTION_EVENT_NOT_FOUND(HttpStatus.FOUND, "해당 이벤트가 없습니다."),
+    PROMOTION_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이벤트가 없습니다."),
     PROMOTION_EVENT_ALREADY(HttpStatus.BAD_REQUEST, "이미 시작한 이벤트는 수정 및 삭제 할 수 없습니다."),
     PROMOTION_EVENT_NOT_START_AND_END_TIME(HttpStatus.BAD_REQUEST, "startDateTime 과 endDateTime 이 존재하지 않습니다."),
     PROMOTION_EVENT_END(HttpStatus.BAD_REQUEST, "이미 끝난 이벤트 입니다."),

--- a/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
@@ -16,15 +16,15 @@ public enum ErrorCode {
     POPUP_STORE_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 팝업스토어가 없습니다."),
     POPUP_STORE_NOT_RESERVATION(HttpStatus.INTERNAL_SERVER_ERROR,"예약한 팝업스토어가 아닙니다."),
     // event error
-    PROMOTION_EVENT_NOT(HttpStatus.FORBIDDEN, "이벤트를 다시 한번 확인해주세요."),
+    PROMOTION_EVENT_NOT_FOUND(HttpStatus.FOUND, "해당 이벤트가 없습니다."),
     PROMOTION_EVENT_ALREADY(HttpStatus.BAD_REQUEST, "이미 시작한 이벤트는 수정 및 삭제 할 수 없습니다."),
     PROMOTION_EVENT_NOT_START_AND_END_TIME(HttpStatus.BAD_REQUEST, "startDateTime 과 endDateTime 이 존재하지 않습니다."),
+    PROMOTION_EVENT_END(HttpStatus.BAD_REQUEST, "이미 끝난 이벤트 입니다."),
     // review error
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,"수정할 리뷰가 없습니다."),
     REVIEW_NOT_UPDATE(HttpStatus.FORBIDDEN,"작성자만 수정할 수 있습니다."),
     REVIEW_ALREADY_DELETED(HttpStatus.NOT_FOUND,"이미 삭제된 리뷰입니다."),
     REVIEW_CANT_DELETE(HttpStatus.BAD_REQUEST,"삭제권한이 없습니다."),
-    PROMOTION_EVENT_END(HttpStatus.BAD_REQUEST, "이미 끝난 이벤트 입니다."),
     // coupon error
     COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST,"쿠폰이 모두 소진되었습니다."),
     COUPON_DUPLICATE_ISSUANCE(HttpStatus.BAD_REQUEST, "이미 발급 받으신 쿠폰입니다."),
@@ -41,7 +41,7 @@ public enum ErrorCode {
     SOCIAL_TOKEN_FAULT(HttpStatus.UNAUTHORIZED, "소셜 로그인 토큰 조회 실패"),
     SOCIAL_USERINFO_FAULT(HttpStatus.BAD_REQUEST, "소셜 로그인 유저 정보 조회 실패"),
 
-    //image,
+    //image
     NOT_CORRECT_FORMAT(HttpStatus.BAD_REQUEST, "올바른 파일 형식이 아닙니다."),
     PRE_SIGNED_URL_FAIL(HttpStatus.UNAUTHORIZED, "preSingedUrl 생성 실패"),
     FAIL_DELETE_IMAGE_FILE(HttpStatus.UNAUTHORIZED, "이미지 파일 삭제에 실패했습니다."),

--- a/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/popupstore/domain/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     REVIEW_NOT_UPDATE(HttpStatus.FORBIDDEN,"작성자만 수정할 수 있습니다."),
     REVIEW_ALREADY_DELETED(HttpStatus.NOT_FOUND,"이미 삭제된 리뷰입니다."),
     REVIEW_CANT_DELETE(HttpStatus.BAD_REQUEST,"삭제권한이 없습니다."),
+    PROMOTION_EVENT_END(HttpStatus.BAD_REQUEST, "이미 끝난 이벤트 입니다."),
     // coupon error
     COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST,"쿠폰이 모두 소진되었습니다."),
     COUPON_DUPLICATE_ISSUANCE(HttpStatus.BAD_REQUEST, "이미 발급 받으신 쿠폰입니다."),
@@ -40,7 +41,7 @@ public enum ErrorCode {
     SOCIAL_TOKEN_FAULT(HttpStatus.UNAUTHORIZED, "소셜 로그인 토큰 조회 실패"),
     SOCIAL_USERINFO_FAULT(HttpStatus.BAD_REQUEST, "소셜 로그인 유저 정보 조회 실패"),
 
-    //image
+    //image,
     NOT_CORRECT_FORMAT(HttpStatus.BAD_REQUEST, "올바른 파일 형식이 아닙니다."),
     PRE_SIGNED_URL_FAIL(HttpStatus.UNAUTHORIZED, "preSingedUrl 생성 실패"),
     FAIL_DELETE_IMAGE_FILE(HttpStatus.UNAUTHORIZED, "이미지 파일 삭제에 실패했습니다."),

--- a/src/main/java/com/sparta/popupstore/domain/popupstore/dto/request/PopupStoreUpdateRequestDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/popupstore/dto/request/PopupStoreUpdateRequestDto.java
@@ -28,7 +28,7 @@ public class PopupStoreUpdateRequestDto {
     private String price;
     @NotBlank(message = "팝업스토어 내용을 입력해주세요.")
     private String content;
-    private String imagePath;
+    private String imageUrl;
     @NotBlank(message = "팝업스토어 주소를 입력해주세요.")
     private String address;
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -9,17 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface PromotionEventRepository extends JpaRepository<PromotionEvent, Long> {
-    @Query("select p from PromotionEvent p left join fetch p.popupStore where p.deletedAt is null")
+    @Query("select p from PromotionEvent p left join fetch p.popupStore")
     Page<PromotionEvent> findAllPromotionalEvents(Pageable pageable);
 
     @Modifying
     @Query("update PromotionEvent p set p.deletedAt = now() where p.id = :promotionEventId")
     void deletePromotionEvent(@Param("promotionEventId") Long promotionEventId);
-
-    Optional<PromotionEvent> findByIdAndDeletedAtIsNull(Long promotionEventId);
 
     @Modifying
     @Query("delete from PromotionEvent p where p in :promotionEvents")

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,8 +19,7 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query("update PromotionEvent p set p.deletedAt = now() where p.id = :promotionEventId")
     void deletePromotionEvent(@Param("promotionEventId") Long promotionEventId);
 
-    @Query("select p from PromotionEvent p where p.id = :promotionEventId and p.deletedAt is null")
-    Optional<PromotionEvent> findByPromotionEventId(@Param("promotionEventId") Long promotionEventId);
+    Optional<PromotionEvent> findByIdAndDeletedAtIsNull(Long promotionEventId);
 
     @Modifying
     @Query(value = "delete from events e where timestampdiff(month , e.deleted_at, now()) >= 6", nativeQuery = true)
@@ -31,7 +29,8 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query("update PromotionEvent p set p.deletedAt = now() where p.endDateTime <= now() and p.deletedAt is null")
     void softDeletePromotionEventByTerminated();
 
-    List<PromotionEvent> findAllByEndDateTimeBeforeAndDeletedAtIsNull(LocalDateTime now);
+    @Query(value = "select * from events e where timestampdiff(month , e.deleted_at, now()) >= 6", nativeQuery = true)
+    List<PromotionEvent> findAllByEndDateTimeAfterSixMonths();
 
 //    추후에 스케쥴러에서 쓰일 수도 있을 것 같아서 일단 주석으로 냅두겠습니당
 //    @Modifying

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -22,8 +22,8 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     Optional<PromotionEvent> findByIdAndDeletedAtIsNull(Long promotionEventId);
 
     @Modifying
-    @Query(value = "delete from events e where timestampdiff(month , e.deleted_at, now()) >= 6", nativeQuery = true)
-    void deletePromotionEventByDeletedAtAfterSixMonths();
+    @Query("delete from PromotionEvent p where p in :promotionEvents")
+    void deleteAllByQuery(List<PromotionEvent> promotionEvents);
 
     @Modifying
     @Query("update PromotionEvent p set p.deletedAt = now() where p.endDateTime <= now() and p.deletedAt is null")

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PromotionEventRepository extends JpaRepository<PromotionEvent, Long> {
@@ -28,6 +30,8 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Modifying
     @Query("update PromotionEvent p set p.deletedAt = now() where p.endDateTime <= now() and p.deletedAt is null")
     void softDeletePromotionEventByTerminated();
+
+    List<PromotionEvent> findAllByEndDateTimeBeforeAndDeletedAtIsNull(LocalDateTime now);
 
 //    추후에 스케쥴러에서 쓰일 수도 있을 것 같아서 일단 주석으로 냅두겠습니당
 //    @Modifying

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -25,11 +25,7 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query("delete from PromotionEvent p where p in :promotionEvents")
     void deleteAllByQuery(List<PromotionEvent> promotionEvents);
 
-    @Modifying
-    @Query("update PromotionEvent p set p.deletedAt = now() where p.endDateTime <= now() and p.deletedAt is null")
-    void softDeletePromotionEventByTerminated();
-
-    @Query(value = "select * from events e where timestampdiff(month , e.deleted_at, now()) >= 6", nativeQuery = true)
+    @Query(value = "select * from events e where timestampdiff(month , e.end_date_time, now()) >= 6", nativeQuery = true)
     List<PromotionEvent> findAllByEndDateTimeAfterSixMonths();
 
 //    추후에 스케쥴러에서 쓰일 수도 있을 것 같아서 일단 주석으로 냅두겠습니당

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
@@ -33,7 +33,7 @@ public class PromotionEventEndCouponDeleteScheduler {
                 s3ImageService.deleteImage(event.getImageUrl());
             }
         }
-        promotionEventRepository.deletePromotionEventByDeletedAtAfterSixMonths();
+        promotionEventRepository.deleteAllByQuery(eventList);
     }
 
     @Transactional

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
@@ -42,11 +42,4 @@ public class PromotionEventEndCouponDeleteScheduler {
         log.info("softDeleteCoupon 스케줄러");
         couponRepository.softDeleteCouponByExpiration();
     }
-
-    @Transactional
-    @Scheduled(fixedRate = 3600001) // 1시간마다 실행
-    public void softDeletePromotionEvent(){
-        log.info("이벤트 softDelete 스케줄러");
-        promotionEventRepository.softDeletePromotionEventByTerminated();
-    }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
@@ -24,15 +24,21 @@ public class PromotionEventEndCouponDeleteScheduler {
 
     @Transactional
     @Scheduled(fixedRate = 300000) // 테스트 용
-    @Scheduled(cron = "00 1 0 * * *") // 매일 00시 1분
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00시 00분
     public void hardDeletePromotionEvent() {
         log.info("hardDeletePromotionEvent 스케줄러");
+        List<PromotionEvent> eventList = promotionEventRepository.findAllByEndDateTimeAfterSixMonths();
+        for(PromotionEvent event : eventList){
+            if(ValidUtil.isValidNullAndEmpty(event.getImageUrl())){
+                s3ImageService.deleteImage(event.getImageUrl());
+            }
+        }
         promotionEventRepository.deletePromotionEventByDeletedAtAfterSixMonths();
     }
 
     @Transactional
     @Scheduled(fixedRate = 300000) // 테스트 용
-    @Scheduled(cron = "30 1 0 * * *") // 매일 00시 1분 30초
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00시 00분
     public void softDeleteCoupon() {
         log.info("softDeleteCoupon 스케줄러");
         couponRepository.softDeleteCouponByExpiration();
@@ -42,12 +48,6 @@ public class PromotionEventEndCouponDeleteScheduler {
     @Scheduled(fixedRate = 3600001) // 1시간마다 실행
     public void softDeletePromotionEvent(){
         log.info("이벤트 softDelete 스케줄러");
-        List<PromotionEvent> eventList = promotionEventRepository.findAllByEndDateTimeBeforeAndDeletedAtIsNull(LocalDateTime.now());
-        for(PromotionEvent event : eventList){
-            if(ValidUtil.isValidNullAndEmpty(event.getImageUrl())){
-                s3ImageService.deleteImage(event.getImageUrl());
-            }
-        }
         promotionEventRepository.softDeletePromotionEventByTerminated();
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -100,7 +100,7 @@ public class PromotionEventService {
     }
 
     private PromotionEvent getPromotionEvent(Long promotionEventId) {
-        return promotionEventRepository.findByPromotionEventId(promotionEventId)
+        return promotionEventRepository.findByIdAndDeletedAtIsNull(promotionEventId)
                 .orElseThrow(
                         ()-> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT)
                 );

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -91,6 +91,9 @@ public class PromotionEventService {
     @Transactional
     public CouponCreateResponseDto couponApplyAndIssuance(Long promotionEventId, User user) {
         PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
+        if(promotionEvent.getEndDateTime().isBefore(LocalDateTime.now())){
+            throw new CustomApiException(ErrorCode.PROMOTION_EVENT_END);
+        }
         if(promotionEvent.getCouponGetCount() == promotionEvent.getTotalCount()){
             throw new CustomApiException(ErrorCode.COUPON_SOLD_OUT);
         }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -82,6 +82,9 @@ public class PromotionEventService {
         if(promotionEvent.getStartDateTime().isBefore(LocalDateTime.now())){
             throw new CustomApiException(ErrorCode.PROMOTION_EVENT_ALREADY);
         }
+        if(ValidUtil.isValidNullAndEmpty(promotionEvent.getImageUrl())){
+            s3ImageService.deleteImage(promotionEvent.getImageUrl());
+        }
         promotionEventRepository.deletePromotionEvent(promotionEventId);
     }
 

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -103,9 +103,9 @@ public class PromotionEventService {
     }
 
     private PromotionEvent getPromotionEvent(Long promotionEventId) {
-        return promotionEventRepository.findByIdAndDeletedAtIsNull(promotionEventId)
+        return promotionEventRepository.findById(promotionEventId)
                 .orElseThrow(
-                        ()-> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT)
+                        ()-> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT_FOUND)
                 );
     }
 }


### PR DESCRIPTION
스케줄러에서도 마찬가지로 1시간마다 종료일이 지난 이벤트를 삭제처리 시킬 때 저장된 이미지가 있는 이벤트라면 s3 저장소의 이미지를 같이 삭제하도록 수정