### PR TITLE
[#124] refactor :회사 - 팝업스토어 수정 시 이미지도 수정 할수 있도록 수정

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/popupstore/controller/PopupStoreController.java
+++ b/src/main/java/com/sparta/popupstore/domain/popupstore/controller/PopupStoreController.java
@@ -18,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -51,10 +50,9 @@ public class PopupStoreController {
     public ResponseEntity<PopupStoreUpdateResponseDto> updatePopupStore(
             @PathVariable Long popupStoreId,
             @AuthCompany Company company,
-            @RequestPart("requestDto") @Valid PopupStoreUpdateRequestDto requestDto,
-            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
+            @RequestBody @Valid PopupStoreUpdateRequestDto requestDto
     ) {
-        return ResponseEntity.ok(popupStoreService.updatePopupStore(popupStoreId, company, requestDto, imageFile));
+        return ResponseEntity.ok(popupStoreService.updatePopupStore(popupStoreId, company, requestDto));
     }
 
     @Operation(summary = "팝업 스토어 단건 조회", description = "팝업스토어 단건조회(상세보기)")

--- a/src/main/java/com/sparta/popupstore/domain/popupstore/service/PopupStoreService.java
+++ b/src/main/java/com/sparta/popupstore/domain/popupstore/service/PopupStoreService.java
@@ -107,11 +107,7 @@ public class PopupStoreService {
         List<PopupStoreImage> requestImageList = requestDto.getImages().stream()
                                                                             .map(PopupStoreImageRequestDto::toEntity)
                                                                             .toList();
-        popupStoreImageList.stream()
-                .filter(image ->
-                        !requestImageList.contains(image)
-                )
-                .forEach(image -> s3ImageService.deleteImage(image.getImageUrl()));
+        popupStoreImageList.forEach(image -> s3ImageService.deleteImage(image.getImageUrl()));
         popupStore.updateImages(requestImageList);
     }
 

--- a/src/main/java/com/sparta/popupstore/domain/popupstore/service/PopupStoreService.java
+++ b/src/main/java/com/sparta/popupstore/domain/popupstore/service/PopupStoreService.java
@@ -23,12 +23,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -62,20 +57,20 @@ public class PopupStoreService {
         return new PopupStoreCreateResponseDto(popupStore);
     }
 
-    private String saveImageFile(MultipartFile file) {
-        if (file.isEmpty()) {
-            throw new IllegalArgumentException("File is empty");
-        }
-
-        try {
-            Path path = Paths.get(UPLOAD_URL, System.currentTimeMillis() + "_" + file.getOriginalFilename());
-            Files.createDirectories(path.getParent());
-            Files.write(path, file.getBytes());
-            return path.toString();
-        } catch (IOException e) {
-            throw new CustomApiException(ErrorCode.IMAGE_SAVE_FAILURE);
-        }
-    }
+//    private String saveImageFile(MultipartFile file) {
+//        if (file.isEmpty()) {
+//            throw new IllegalArgumentException("File is empty");
+//        }
+//
+//        try {
+//            Path path = Paths.get(UPLOAD_URL, System.currentTimeMillis() + "_" + file.getOriginalFilename());
+//            Files.createDirectories(path.getParent());
+//            Files.write(path, file.getBytes());
+//            return path.toString();
+//        } catch (IOException e) {
+//            throw new CustomApiException(ErrorCode.IMAGE_SAVE_FAILURE);
+//        }
+//    }
 
     // 관리자 - 팝업 스토어 수정
     @Transactional
@@ -83,23 +78,14 @@ public class PopupStoreService {
         PopupStore popupStore = popupStoreRepository.findById(popupId)
                 .orElseThrow(() -> new CustomApiException(ErrorCode.POPUP_STORE_NOT_FOUND));
 
-        List<PopupStoreImage> popupStoreImageList = popupStore.getPopupStoreImageList();
-        List<PopupStoreImage> requestImageList = requestDto.getImages().stream()
-                                                                            .map(PopupStoreImageRequestDto::toEntity)
-                                                                            .toList();
-        popupStoreImageList.stream()
-                .filter(image ->
-                        !requestImageList.contains(image)
-                )
-                .forEach(image -> s3ImageService.deleteImage(image.getImageUrl()));
-        popupStore.updateImages(requestImageList);
+        this.updateImage(popupStore, requestDto);
         popupStore.update(requestDto);
         return new PopupStoreUpdateResponseDto(popupStoreRepository.save(popupStore));
     }
 
     // 회사 - 팝업 스토어 수정
     @Transactional
-    public PopupStoreUpdateResponseDto updatePopupStore(Long popupId, Company company, PopupStoreUpdateRequestDto requestDto, MultipartFile imageFile) {
+    public PopupStoreUpdateResponseDto updatePopupStore(Long popupId, Company company, PopupStoreUpdateRequestDto requestDto) {
         PopupStore popupStore = popupStoreRepository.findById(popupId)
                 .orElseThrow(() -> new CustomApiException(ErrorCode.POPUP_STORE_NOT_FOUND));
 
@@ -110,11 +96,23 @@ public class PopupStoreService {
         if (!isEditable(popupStore)) {
             throw new CustomApiException(ErrorCode.POPUP_STORE_ALREADY_START);
         }
-
-        if (imageFile != null) saveImageFile(imageFile);
+        this.updateImage(popupStore, requestDto);
         popupStore.update(requestDto);
 
         return new PopupStoreUpdateResponseDto(popupStoreRepository.save(popupStore));
+    }
+
+    private void updateImage(PopupStore popupStore, PopupStoreUpdateRequestDto requestDto) {
+        List<PopupStoreImage> popupStoreImageList = popupStore.getPopupStoreImageList();
+        List<PopupStoreImage> requestImageList = requestDto.getImages().stream()
+                                                                            .map(PopupStoreImageRequestDto::toEntity)
+                                                                            .toList();
+        popupStoreImageList.stream()
+                .filter(image ->
+                        !requestImageList.contains(image)
+                )
+                .forEach(image -> s3ImageService.deleteImage(image.getImageUrl()));
+        popupStore.updateImages(requestImageList);
     }
 
     private boolean isEditable(PopupStore popupStore) {


### PR DESCRIPTION
현재는 관리자, 회사 모두 팝업스토어 수정 시 s3와 db에 저장된 이미지를 모두 삭제하고 다시 채워넣는식입니다.