### PR TITLE
[#84] feat: 동시성 제어(프로모션이벤트) 

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
@@ -20,4 +20,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     @Modifying
     @Query("update Coupon c set c.couponStatus = 'EXPIRATION' where c.couponExpirationPeriod < now() and c.couponStatus = 'ISSUED'")
     void softDeleteCouponByExpiration();
+
+    // 쿠폰 개수 구하기
+    Long countByPromotionEventId(Long promotionEventId);
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/CouponRepository.java
@@ -1,7 +1,9 @@
 package com.sparta.popupstore.domain.promotionevent.repository;
 
 import com.sparta.popupstore.domain.promotionevent.entity.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +25,10 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     // 쿠폰 개수 구하기
     Long countByPromotionEventId(Long promotionEventId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.promotionEventId = :promotionEventId AND c.userId = :userId")
+    Coupon findByIdWithPessimisticLock(@Param("promotionEventId") Long promotionEventId, @Param("userId") Long userId);
+
+
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -25,8 +25,8 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query(value = "select * from events e where timestampdiff(month , e.end_date_time, now()) >= 6", nativeQuery = true)
     List<PromotionEvent> findAllByEndDateTimeAfterSixMonths();
 
-//    추후에 스케쥴러에서 쓰일 수도 있을 것 같아서 일단 주석으로 냅두겠습니당
-//    @Modifying
-//    @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
-//    void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
+    // 동시성 제어 - 프로모션 이벤트 couponGetCount 업데이트 진행
+    @Modifying
+    @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
+    void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -1,9 +1,11 @@
 package com.sparta.popupstore.domain.promotionevent.repository;
 
 import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,8 +27,14 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query(value = "select * from events e where timestampdiff(month , e.end_date_time, now()) >= 6", nativeQuery = true)
     List<PromotionEvent> findAllByEndDateTimeAfterSixMonths();
 
-    // 동시성 제어 - 프로모션 이벤트 couponGetCount 업데이트 진행
+    // 추후 스케줄러에 사용될 수 있음.
     @Modifying
     @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
     void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
+
+    // 프로모션 이벤트 쿠폰 발급 동시성 제어 비관적 락 사용
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from PromotionEvent p where p.id = :promotionEventId")
+    PromotionEvent findByIdWithPessimisticLock(Long promotionEventId);
+
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/CouponService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,10 +19,13 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
 
+    @Transactional
     public Coupon createCoupon(PromotionEvent promotionEvent, User user) {
-        if (couponRepository.existsByPromotionEventIdAndUserId(promotionEvent.getId(), user.getId())) {
+        Coupon existingCoupon = couponRepository.findByIdWithPessimisticLock(promotionEvent.getId(), user.getId());
+        if (existingCoupon != null) {
             throw new CustomApiException(ErrorCode.COUPON_DUPLICATE_ISSUANCE);
         }
+
         String uuid = UUID.randomUUID().toString();
         Coupon coupon = Coupon.builder()
                 .userId(user.getId())

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -97,7 +97,7 @@ public class PromotionEventService {
 
     @Transactional
     public CouponCreateResponseDto couponApplyAndIssuance(Long promotionEventId, User user) {
-        PromotionEvent promotionEvent = this.getPromotionEvent(promotionEventId);
+        PromotionEvent promotionEvent = promotionEventRepository.findByIdWithPessimisticLock(promotionEventId);
         if(promotionEvent.getEndDateTime().isBefore(LocalDateTime.now())){
             throw new CustomApiException(ErrorCode.PROMOTION_EVENT_END);
         }
@@ -106,8 +106,12 @@ public class PromotionEventService {
         }
         Coupon coupon = couponService.createCoupon(promotionEvent, user);
 
-        // couponGetCount 업데이트
-        promotionEventRepository.couponGetCountUp(promotionEventId);
+        // 선착순 개수 +
+        promotionEvent.couponGetCountUp();
+        System.out.println("선착순 개수 확인 :"+promotionEvent.getCouponGetCount());
+
+//        // couponGetCount 업데이트
+//        promotionEventRepository.couponGetCountUp(promotionEventId);
 
         return new CouponCreateResponseDto(coupon);
     }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventService.java
@@ -105,7 +105,10 @@ public class PromotionEventService {
             throw new CustomApiException(ErrorCode.COUPON_SOLD_OUT);
         }
         Coupon coupon = couponService.createCoupon(promotionEvent, user);
-        promotionEvent.couponGetCountUp();
+
+        // couponGetCount 업데이트
+        promotionEventRepository.couponGetCountUp(promotionEventId);
+
         return new CouponCreateResponseDto(coupon);
     }
 

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
@@ -2,6 +2,7 @@ package com.sparta.popupstore.domain.promotionevent.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.sparta.popupstore.domain.common.exception.CustomApiException;
@@ -11,6 +12,8 @@ import com.sparta.popupstore.domain.promotionevent.repository.CouponRepository;
 import com.sparta.popupstore.domain.promotionevent.repository.PromotionEventRepository;
 import com.sparta.popupstore.domain.user.entity.User;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -63,9 +66,17 @@ public class CouponServiceTest {
     public void testCouponConcurrency() throws InterruptedException {
         Long promotionEventId = 2L;
         ExecutorService executorService = Executors.newFixedThreadPool(100);
-        when(user.getId()).thenReturn(1L);
+//        when(user.getId()).thenReturn(1L);
+        // 객체 여러명 생성 반복문
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            User user = mock(User.class);
+            when(user.getId()).thenReturn((long)(i + 1));
+            users.add(user);
+        }
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 1; i <= 100; i++) {
+            final User user = users.get(i % 10);
             executorService.submit(() -> {
                 try {
                     promotionEventService.couponApplyAndIssuance(promotionEventId, user);

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
@@ -1,0 +1,88 @@
+package com.sparta.popupstore.domain.promotionevent.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.sparta.popupstore.domain.common.exception.CustomApiException;
+import com.sparta.popupstore.domain.common.exception.ErrorCode;
+import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
+import com.sparta.popupstore.domain.promotionevent.repository.CouponRepository;
+import com.sparta.popupstore.domain.promotionevent.repository.PromotionEventRepository;
+import com.sparta.popupstore.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class CouponServiceTest {
+
+    @Autowired
+    private PromotionEventService promotionEventService;
+
+    @Autowired
+    private PromotionEventRepository promotionEventRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponService couponService;
+
+    private PromotionEvent promotionEvent;
+
+    @MockBean
+    private User user;  // User 객체를 MockBean으로 설정
+
+
+//    @BeforeEach
+//    public void setup() {
+//        // 이벤트 초기화 (couponGetCount 초기값을 0으로 설정)
+//
+//        promotionEvent = PromotionEvent.builder()
+//            .couponGetCount(0)
+//            .totalCount(10)
+//            .discountPercentage(10)
+//            .couponExpirationPeriod(30)
+//            .title("선착순테스트")
+//            .description("설명설명")
+//            .endDateTime(LocalDateTime.now())
+//            .build();
+//        promotionEventRepository.save(promotionEvent);
+//    }
+
+    @Test
+    @DisplayName("이벤트 쿠폰 선착순 10명 - 100명 동시성 제어 테스트")
+    public void testCouponConcurrency() throws InterruptedException {
+        Long promotionEventId = 2L;
+        ExecutorService executorService = Executors.newFixedThreadPool(100);
+        when(user.getId()).thenReturn(1L);
+
+        for (int i = 0; i < 100; i++) {
+            executorService.submit(() -> {
+                try {
+                    promotionEventService.couponApplyAndIssuance(promotionEventId, user);
+                } catch (CustomApiException e) {
+                    System.out.println("쿠폰 지급 한도 초과");
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        PromotionEvent promotionEvent = promotionEventRepository.findById(promotionEventId)
+            .orElseThrow(() -> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT_FOUND));
+        assertTrue(promotionEvent.getCouponGetCount() <= 10);
+
+        long couponCount = couponRepository.countByPromotionEventId(promotionEventId);
+        assertEquals(10, couponCount);
+    }
+}

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
@@ -61,7 +61,7 @@ public class CouponServiceTest {
     public void testCouponConcurrency10() throws InterruptedException {
         final int threads = 100;
         final int usersCount = 10;
-        final int Count = 5;
+        final int count = 5;
 
 
         Long promotionEventId = 2L;
@@ -91,17 +91,17 @@ public class CouponServiceTest {
 
         PromotionEvent promotionEvent = promotionEventRepository.findById(promotionEventId)
             .orElseThrow(() -> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT_FOUND));
-        assertTrue(promotionEvent.getCouponGetCount() <= Count);
+        assertTrue(promotionEvent.getCouponGetCount() <= count);
 
         long couponCount = couponRepository.countByPromotionEventId(promotionEventId);
-        assertEquals(Count, couponCount);
+        assertEquals(count, couponCount);
     }
 
     @Test
     @DisplayName("이벤트 쿠폰 선착순 10명 - 스레드 100(user DB 100명용)")
     public void testCouponConcurrency100() throws InterruptedException {
         final int threads = 100;
-        final int Count = 10;
+        final int count = 10;
 
         Long promotionEventId = 2L;
         ExecutorService executorService = Executors.newFixedThreadPool(threads);
@@ -122,9 +122,9 @@ public class CouponServiceTest {
 
         PromotionEvent promotionEvent = promotionEventRepository.findById(promotionEventId)
             .orElseThrow(() -> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT_FOUND));
-        assertTrue(promotionEvent.getCouponGetCount() <= Count);
+        assertTrue(promotionEvent.getCouponGetCount() <= count);
 
         long couponCount = couponRepository.countByPromotionEventId(promotionEventId);
-        assertEquals(Count, couponCount);
+        assertEquals(count, couponCount);
     }
 }

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
@@ -40,6 +40,8 @@ public class CouponServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+//    PromotionEvent promotionEvent;
+//
 //    @BeforeEach
 //    public void setup() {
 //        // 이벤트 초기화 (couponGetCount 초기값을 0으로 설정)
@@ -58,7 +60,7 @@ public class CouponServiceTest {
 
     @Test
     @Transactional
-    @DisplayName("이벤트 쿠폰 선착순 5명 - 10명이 경쟁 / 100개 스레드(user DB 10명용)")
+    @DisplayName("이벤트 쿠폰 선착순 5명 - 10명이 경쟁 (user DB 10명용)")
     public void testCouponConcurrency10() throws InterruptedException {
         final int threads = 100;
         final int usersCount = 10;
@@ -75,8 +77,7 @@ public class CouponServiceTest {
             users.add(user);
         }
 
-        for (int i = 1; i <= threads; i++) {
-            final User user = users.get(i % usersCount);
+        for (User user : users) {
             executorService.submit(() -> {
                 try {
                     promotionEventService.couponApplyAndIssuance(promotionEventId, user);
@@ -99,7 +100,7 @@ public class CouponServiceTest {
 
     @Test
     @Transactional
-    @DisplayName("이벤트 쿠폰 선착순 10명 - 스레드 100(user DB 100명용)")
+    @DisplayName("이벤트 쿠폰 선착순 10명 - 100명이 경쟁 (user DB 100명용)")
     public void testCouponConcurrency100() throws InterruptedException {
         final int threads = 100;
         final int count = 10;

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
@@ -40,15 +40,6 @@ public class CouponServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private CouponService couponService;
-
-    private PromotionEvent promotionEvent;
-
-    @MockBean
-    private User user;  // User 객체를 MockBean으로 설정
-
-
 //    @BeforeEach
 //    public void setup() {
 //        // 이벤트 초기화 (couponGetCount 초기값을 0으로 설정)
@@ -66,10 +57,11 @@ public class CouponServiceTest {
 //    }
 
     @Test
-    @DisplayName("이벤트 쿠폰 선착순 10명 - 100명 동시성 제어 테스트")
+    @DisplayName("이벤트 쿠폰 선착순 5명 - 10명이 경쟁 / 100개 스레드(user DB 10명용)")
     public void testCouponConcurrency10() throws InterruptedException {
-        final int threads = 1000;
+        final int threads = 100;
         final int usersCount = 10;
+        final int Count = 5;
 
 
         Long promotionEventId = 2L;
@@ -99,17 +91,17 @@ public class CouponServiceTest {
 
         PromotionEvent promotionEvent = promotionEventRepository.findById(promotionEventId)
             .orElseThrow(() -> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT_FOUND));
-        assertTrue(promotionEvent.getCouponGetCount() <= usersCount);
+        assertTrue(promotionEvent.getCouponGetCount() <= Count);
 
         long couponCount = couponRepository.countByPromotionEventId(promotionEventId);
-        assertEquals(usersCount, couponCount);
+        assertEquals(Count, couponCount);
     }
 
     @Test
-    @DisplayName("이벤트 쿠폰 선착순 100명 - 스레드 1000")
+    @DisplayName("이벤트 쿠폰 선착순 10명 - 스레드 100(user DB 100명용)")
     public void testCouponConcurrency100() throws InterruptedException {
-        final int threads = 1000;
-        final int usersCount = 100;
+        final int threads = 100;
+        final int Count = 10;
 
         Long promotionEventId = 2L;
         ExecutorService executorService = Executors.newFixedThreadPool(threads);
@@ -130,9 +122,9 @@ public class CouponServiceTest {
 
         PromotionEvent promotionEvent = promotionEventRepository.findById(promotionEventId)
             .orElseThrow(() -> new CustomApiException(ErrorCode.PROMOTION_EVENT_NOT_FOUND));
-        assertTrue(promotionEvent.getCouponGetCount() <= usersCount);
+        assertTrue(promotionEvent.getCouponGetCount() <= Count);
 
         long couponCount = couponRepository.countByPromotionEventId(promotionEventId);
-        assertEquals(usersCount, couponCount);
+        assertEquals(Count, couponCount);
     }
 }

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/CouponServiceTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 public class CouponServiceTest {
@@ -57,12 +57,12 @@ public class CouponServiceTest {
 //    }
 
     @Test
+    @Transactional
     @DisplayName("이벤트 쿠폰 선착순 5명 - 10명이 경쟁 / 100개 스레드(user DB 10명용)")
     public void testCouponConcurrency10() throws InterruptedException {
         final int threads = 100;
         final int usersCount = 10;
         final int count = 5;
-
 
         Long promotionEventId = 2L;
         ExecutorService executorService = Executors.newFixedThreadPool(threads);
@@ -98,6 +98,7 @@ public class CouponServiceTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("이벤트 쿠폰 선착순 10명 - 스레드 100(user DB 100명용)")
     public void testCouponConcurrency100() throws InterruptedException {
         final int threads = 100;


### PR DESCRIPTION
동시성 제어 시나리오)
- 선착순 10명에게 지급되는 할인쿠폰을 100명의 사용자가 몰리는 상황
- couponGetCount가 0이고 10이 될때까지 동시성은 진행
- couponGetCount가 +1 되면 
- INSERT INTO coupons해서 coupons 데이터가 1개 쌓여야한다.
※ totalCount와 couponGetCount가 같아지면 종료(이때 coupon의 개수도 그에 맞게 insert되어있어야함.)

[1차 시도 - 실패]
과정)
- 하승님이 만들어두신 메서드를 그대로 활용하여 @SpringBootTest로 진행

주의사항)
- 팝업스토어id 필수
- 고객 id 필수(쿠폰을 발급받는 고객 id)
- 종료일을 현재시간과 비교해서 여유롭게 값을 넣어줘야함.

결과)
- couponGetCount 정상
- 쿠폰 10개 발급 정상
---------------------------------------------------

[2차 시도 - 성공]
과정)
- couponGetCount 선착순 증가 메서드 entity에 있는 메서드로 재 적용
- repository에서 프로모션이벤트에 대해서 select로 조회하고 비관적 락 적용

주의사항)
- 100개 반복문 돌리는 부분에서 테스트 하는 인원에 맞게 계산해줘야함.
![image](https://github.com/user-attachments/assets/124ac7c8-fd1d-46d9-b150-7284a84a7329)
- 현재는 10명으로 % 10 으로 나머지 연산 해주고있음.

결과)
- 선착순 3,5,10명으로 테스트 진행
- 똑같이 각각에 대하여 100명이 몰리도록 설정
- couponGetCount 정상
- 쿠폰 3,5,10개 발급 정상
![image](https://github.com/user-attachments/assets/e74d782b-891c-4632-9d9e-22a99c9f4376)


