### PR TITLE
[#182] fix : 현재 날짜기준 팝업 조회 시 문제 수정

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/popupstore/repository/PopupStoreQueryDslImpl.java
+++ b/src/main/java/com/sparta/popupstore/domain/popupstore/repository/PopupStoreQueryDslImpl.java
@@ -23,7 +23,7 @@ public class PopupStoreQueryDslImpl implements PopupStoreQueryDsl {
     @Override
     public Page<PopupStore> findByStatus(Pageable pageable, PopupStoreStatus popupStoreStatus) {
         LocalDate fromDate = LocalDate.now();
-        LocalDate toDate = fromDate;
+        LocalDate toDate = fromDate.plusDays(1);
 
        return this.getPopupStores(pageable, fromDate, toDate, popupStoreStatus);
     }
@@ -64,7 +64,7 @@ public class PopupStoreQueryDslImpl implements PopupStoreQueryDsl {
     private BooleanExpression findByStatus(LocalDate fromDate, LocalDate toDate, PopupStoreStatus popupStoreStatus) {
         return switch (popupStoreStatus) {
             case ALL -> null;
-            case SCHEDULE -> popupStore.startDate.between(toDate.plusDays(1), toDate.plusWeeks(1));
+            case SCHEDULE -> popupStore.startDate.between(toDate, toDate.plusWeeks(1));
             case OPEN -> popupStore.startDate.before(toDate).and(popupStore.endDate.after(fromDate.minusDays(1)));
             case CLOSE -> popupStore.endDate.before(fromDate);
         };


### PR DESCRIPTION
현재 진행중인 팝업을 조회 시에 오늘 시작한 팝업이 조회 되지 않는 이슈

schedule과 open 모두 todate.plusDays(1) 을 사용하기 때문에 위에서 한번에 처리
```java
LocalDate fromDate = LocalDate.now();
LocalDate toDate = fromDate.plusDays(1);

case SCHEDULE -> popupStore.startDate.between(toDate, toDate.plusWeeks(1));
 case OPEN -> popupStore.startDate.before(toDate).and(popupStore.endDate.after(fromDate.minusDays(1)));
```