### PR TITLE
[#186] fix : 이벤트 삭제 스케줄러 메서드 변경

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -18,10 +18,6 @@ public interface PromotionEventRepository extends JpaRepository<PromotionEvent, 
     @Query("update PromotionEvent p set p.deletedAt = now() where p.id = :promotionEventId")
     void deletePromotionEvent(@Param("promotionEventId") Long promotionEventId);
 
-    @Modifying
-    @Query("delete from PromotionEvent p where p in :promotionEvents")
-    void deleteAllByQuery(List<PromotionEvent> promotionEvents);
-
     @Query(value = "select * from events e where timestampdiff(month , e.end_date_time, now()) >= 6", nativeQuery = true)
     List<PromotionEvent> findAllByEndDateTimeAfterSixMonths();
 

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
@@ -32,7 +32,7 @@ public class PromotionEventEndCouponDeleteScheduler {
                 s3ImageService.deleteImage(event.getImageUrl());
             }
         }
-        promotionEventRepository.deleteAllByQuery(eventList);
+        promotionEventRepository.deleteAllInBatch(eventList);
     }
 
     @Transactional


### PR DESCRIPTION
deleteAll 같은 경우엔 이벤트 수 만큼 쿼리가 발생해서 임의로 만들어서 사용했었는데
deleteAllInBatch 라는 메서드가 있더라구요 아래 sql 처럼 where로 묶어서 이벤트들을 삭제해줍니다.
그래서 따로 만들어서 쓸 필요없이 해당 메서드로 사용하는게 좋을 것 같아서 바꿨습니다
```sql
Hibernate: 
    delete pe1_0 
    from
        events pe1_0 
    where
        pe1_0.id=? 
        or pe1_0.id=?
```