### PR TITLE
[#197] refactor : 이벤트 로직 변경

### DIFF
--- a/src/main/java/com/sparta/popupstore/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/sparta/popupstore/domain/admin/controller/AdminController.java
@@ -115,12 +115,11 @@ public class AdminController {
     @CheckAdmin
     @PostMapping("/promotionEvents")
     public ResponseEntity<PromotionEventCreateResponseDto> createEvent(
-            @Valid @RequestBody PromotionEventCreateRequestDto createRequestDto,
-            @RequestParam(required = false, name = "popupStoreId") Long popupStoreId
+            @Valid @RequestBody PromotionEventCreateRequestDto createRequestDto
     ) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(promotionEventService.createEvent(createRequestDto, popupStoreId));
+                .body(promotionEventService.createEvent(createRequestDto));
     }
 
     @Operation(summary = "프로모션 이벤트 수정")

--- a/src/main/java/com/sparta/popupstore/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/sparta/popupstore/domain/admin/controller/AdminController.java
@@ -13,7 +13,6 @@ import com.sparta.popupstore.domain.popupstore.service.PopupStoreService;
 import com.sparta.popupstore.domain.promotionevent.dto.request.PromotionEventCreateRequestDto;
 import com.sparta.popupstore.domain.promotionevent.dto.request.PromotionEventUpdateRequestDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventCreateResponseDto;
-import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindOneResponseDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventUpdateResponseDto;
 import com.sparta.popupstore.domain.promotionevent.service.PromotionEventService;
 import com.sparta.popupstore.jwt.JwtUtil;
@@ -122,17 +121,6 @@ public class AdminController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(promotionEventService.createEvent(createRequestDto, popupStoreId));
-    }
-
-    @Operation(summary = "프로모션 이벤트 단건 조회")
-    @Parameter(name = "promotionEventId", description = "조회 할 프로모션 이벤트의 기본키")
-    @GetMapping("/promotionEvents/{promotionEventId}")
-    public ResponseEntity<PromotionEventFindOneResponseDto> findOnePromotionalEvent(
-            @PathVariable(name = "promotionEventId") Long promotionEventId
-    ) {
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(promotionEventService.findOnePromotionEvent(promotionEventId));
     }
 
     @Operation(summary = "프로모션 이벤트 수정")

--- a/src/main/java/com/sparta/popupstore/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/popupstore/domain/coupon/entity/Coupon.java
@@ -34,13 +34,13 @@ public class Coupon {
     protected LocalDateTime createdAt;
 
     @Builder
-    public Coupon(Long userId, PromotionEvent promotionEvent, String serialNumber, Long couponId, CouponStatus couponStatus) {
-        this.id = couponId;
+    public Coupon(Long id, Long userId, PromotionEvent promotionEvent, String serialNumber, CouponStatus couponStatus, LocalDate couponExpirationPeriod) {
+        this.id = id;
         this.userId = userId;
         this.promotionEventId = promotionEvent.getId();
         this.popupStoreId = promotionEvent.getPopupStoreId();
         this.serialNumber = serialNumber;
         this.couponStatus = couponStatus;
-        this.couponExpirationPeriod = LocalDate.now().plusDays(promotionEvent.getCouponExpirationPeriod());
+        this.couponExpirationPeriod = couponExpirationPeriod;
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/popupstore/domain/coupon/entity/Coupon.java
@@ -38,7 +38,7 @@ public class Coupon {
         this.id = couponId;
         this.userId = userId;
         this.promotionEventId = promotionEvent.getId();
-        this.popupStoreId = promotionEvent.getPopupStore() != null ? promotionEvent.getPopupStore().getId() : null;
+        this.popupStoreId = promotionEvent.getPopupStoreId();
         this.serialNumber = serialNumber;
         this.couponStatus = couponStatus;
         this.couponExpirationPeriod = LocalDate.now().plusDays(promotionEvent.getCouponExpirationPeriod());

--- a/src/main/java/com/sparta/popupstore/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/popupstore/domain/coupon/service/CouponService.java
@@ -10,6 +10,7 @@ import com.sparta.popupstore.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class CouponService {
                 .promotionEvent(promotionEvent)
                 .serialNumber(uuid)
                 .couponStatus(CouponStatus.ISSUED)
+                .couponExpirationPeriod(LocalDate.now().plusDays(promotionEvent.getCouponExpirationPeriod()))
                 .build();
         return couponRepository.save(coupon);
     }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/controller/PromotionEventController.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/controller/PromotionEventController.java
@@ -3,6 +3,7 @@ package com.sparta.popupstore.domain.promotionevent.controller;
 import com.sparta.popupstore.domain.common.annotation.AuthUser;
 import com.sparta.popupstore.domain.coupon.dto.response.CouponCreateResponseDto;
 import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindAllResponseDto;
+import com.sparta.popupstore.domain.promotionevent.dto.response.PromotionEventFindOneResponseDto;
 import com.sparta.popupstore.domain.promotionevent.service.PromotionEventService;
 import com.sparta.popupstore.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,5 +43,16 @@ public class PromotionEventController {
             @AuthUser User user
     ) {
         return ResponseEntity.ok(promotionEventService.couponApplyAndIssuance(promotionEventId, user));
+    }
+
+    @Operation(summary = "프로모션 이벤트 단건 조회")
+    @Parameter(name = "promotionEventId", description = "조회 할 프로모션 이벤트의 기본키")
+    @GetMapping("/{promotionEventId}")
+    public ResponseEntity<PromotionEventFindOneResponseDto> findOnePromotionalEvent(
+            @PathVariable(name = "promotionEventId") Long promotionEventId
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(promotionEventService.findOnePromotionEvent(promotionEventId));
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/request/PromotionEventCreateRequestDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/request/PromotionEventCreateRequestDto.java
@@ -29,17 +29,20 @@ public class PromotionEventCreateRequestDto {
     @NotNull(message = "이벤트 종료 시각은 공백일 수 없습니다.")
     private LocalDateTime endDateTime;
     private String imageUrl;
+    private Long popupStoreId;
 
-    public PromotionEvent toEvent() {
+    public PromotionEvent toEntity() {
         return PromotionEvent.builder()
                 .title(this.title)
                 .description(this.description)
                 .discountPercentage(this.discountPercentage)
                 .totalCount(this.totalCount)
+                .couponGetCount(0)
                 .couponExpirationPeriod(this.couponExpirationPeriod)
                 .startDateTime(this.startDateTime)
                 .endDateTime(this.endDateTime)
                 .imageUrl(this.imageUrl)
+                .popupStoreId(this.popupStoreId)
                 .build();
     }
 }

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/response/PromotionEventCreateResponseDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/response/PromotionEventCreateResponseDto.java
@@ -31,7 +31,7 @@ public class PromotionEventCreateResponseDto {
 
     public PromotionEventCreateResponseDto(PromotionEvent promotionEvent) {
         this.id = promotionEvent.getId();
-        this.popupStoreId = promotionEvent.getPopupStore() != null ? promotionEvent.getPopupStore().getId() : null;
+        this.popupStoreId = promotionEvent.getPopupStoreId();
         this.title = promotionEvent.getTitle();
         this.description = promotionEvent.getDescription();
         this.discountPercentage = promotionEvent.getDiscountPercentage();

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/response/PromotionEventFindAllResponseDto.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/dto/response/PromotionEventFindAllResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.popupstore.domain.promotionevent.dto.response;
 
+import com.sparta.popupstore.domain.popupstore.entity.PopupStore;
 import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -29,11 +30,11 @@ public class PromotionEventFindAllResponseDto {
     @Schema(description = "이미지 저장된 경로")
     private final String imageUrl;
 
-    public PromotionEventFindAllResponseDto(PromotionEvent promotionEvent) {
+    public PromotionEventFindAllResponseDto(PromotionEvent promotionEvent, PopupStore popupStore) {
         this.id = promotionEvent.getId();
         this.title = promotionEvent.getTitle();
         this.description = promotionEvent.getDescription();
-        this.promotionEventFindAllPopupStoreResponseDto = promotionEvent.getPopupStore() != null ? new PromotionEventFindAllPopupStoreResponseDto(promotionEvent.getPopupStore()) : null;
+        this.promotionEventFindAllPopupStoreResponseDto = popupStore != null ? new PromotionEventFindAllPopupStoreResponseDto(popupStore) : null;
         this.discountPercentage = promotionEvent.getDiscountPercentage();
         this.totalCount = promotionEvent.getTotalCount();
         this.couponExpirationPeriod = promotionEvent.getCouponExpirationPeriod();

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/PromotionEvent.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/PromotionEvent.java
@@ -48,16 +48,12 @@ public class PromotionEvent extends BaseEntity {
         this.title = title;
         this.description = description;
         this.discountPercentage = discountPercentage;
-        this.couponGetCount = 0;
+        this.couponGetCount = couponGetCount;
         this.totalCount = totalCount;
         this.couponExpirationPeriod = couponExpirationPeriod;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.imageUrl = imageUrl;
-    }
-
-    public void addPopupStore(Long popupStoreId){
-        this.popupStoreId = popupStoreId;
     }
 
     public void updatePromotionEvent(

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/PromotionEvent.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/entity/PromotionEvent.java
@@ -1,7 +1,6 @@
 package com.sparta.popupstore.domain.promotionevent.entity;
 
 import com.sparta.popupstore.domain.common.entity.BaseEntity;
-import com.sparta.popupstore.domain.popupstore.entity.PopupStore;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,9 +18,7 @@ public class PromotionEvent extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "popupstore_id")
-    private PopupStore popupStore;
+    private Long popupStoreId;
     private String title;
     private String description;
     private Integer discountPercentage;
@@ -35,7 +32,7 @@ public class PromotionEvent extends BaseEntity {
     @Builder
     public PromotionEvent(
             Long id,
-            PopupStore popupStore,
+            Long popupStoreId,
             String title,
             String description,
             Integer discountPercentage,
@@ -47,11 +44,11 @@ public class PromotionEvent extends BaseEntity {
             String imageUrl
     ) {
         this.id = id;
-        this.popupStore = popupStore;
+        this.popupStoreId = popupStoreId;
         this.title = title;
         this.description = description;
         this.discountPercentage = discountPercentage;
-        this.couponGetCount = couponGetCount;
+        this.couponGetCount = 0;
         this.totalCount = totalCount;
         this.couponExpirationPeriod = couponExpirationPeriod;
         this.startDateTime = startDateTime;
@@ -59,8 +56,8 @@ public class PromotionEvent extends BaseEntity {
         this.imageUrl = imageUrl;
     }
 
-    public void addPopupStore(PopupStore popupStore){
-        this.popupStore = popupStore;
+    public void addPopupStore(Long popupStoreId){
+        this.popupStoreId = popupStoreId;
     }
 
     public void updatePromotionEvent(

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -2,8 +2,6 @@ package com.sparta.popupstore.domain.promotionevent.repository;
 
 import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,9 +11,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface PromotionEventRepository extends JpaRepository<PromotionEvent, Long> {
-    @Query("select p from PromotionEvent p left join fetch p.popupStore")
-    Page<PromotionEvent> findAllPromotionalEvents(Pageable pageable);
-
     @Modifying
     @Query("update PromotionEvent p set p.deletedAt = now() where p.id = :promotionEventId")
     void deletePromotionEvent(@Param("promotionEventId") Long promotionEventId);

--- a/src/test/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventServiceTest.java
+++ b/src/test/java/com/sparta/popupstore/domain/promotionevent/service/PromotionEventServiceTest.java
@@ -36,9 +36,11 @@ class PromotionEventServiceTest {
     void createEventTest1() {
         // given
         Long popupStoreId = 1L;
-        PromotionEventCreateRequestDto requestDto = PromotionEventCreateRequestDto.builder().build();
+        PromotionEventCreateRequestDto requestDto = PromotionEventCreateRequestDto.builder()
+                .popupStoreId(popupStoreId)
+                .build();
         // when
-        String exception = assertThrows(CustomApiException.class , () -> promotionEventService.createEvent(requestDto, popupStoreId)).getMessage();
+        String exception = assertThrows(CustomApiException.class , () -> promotionEventService.createEvent(requestDto)).getMessage();
         // then
         assertEquals("해당 팝업스토어가 없습니다." , exception);
     }
@@ -47,13 +49,12 @@ class PromotionEventServiceTest {
     @DisplayName("팝업스토어 고유번호가 null 이라면 이벤트의 팝업스토어 컬럼 null 로 저장")
     void createEventTest2() {
         // given
-        Long popupStoreId = null;
-        PromotionEventCreateRequestDto requestDto = PromotionEventCreateRequestDto.builder().build();
+        PromotionEventCreateRequestDto requestDto = PromotionEventCreateRequestDto.builder().popupStoreId(null).build();
         PromotionEvent promotionEvent = PromotionEvent.builder()
                 .build();
         // when
         when(promotionEventRepository.save(any())).thenReturn(promotionEvent);
-        PromotionEventCreateResponseDto responseDto = promotionEventService.createEvent(requestDto, popupStoreId);
+        PromotionEventCreateResponseDto responseDto = promotionEventService.createEvent(requestDto);
 
         // then
         assertNull(responseDto.getPopupStoreId());
@@ -65,6 +66,7 @@ class PromotionEventServiceTest {
         // given
         Long popupStoreId = 1L;
         PromotionEventCreateRequestDto requestDto = PromotionEventCreateRequestDto.builder()
+                .popupStoreId(popupStoreId)
                 .endDateTime(LocalDateTime.now().plusDays(2))
                 .build();
         PopupStore popupStore = PopupStore.builder()
@@ -73,13 +75,13 @@ class PromotionEventServiceTest {
                 .build();
         PromotionEvent promotionEvent = PromotionEvent.builder()
                 .id(3L)
-                .popupStore(popupStore)
+                .popupStoreId(popupStoreId)
                 .endDateTime(LocalDateTime.now().plusDays(2))
                 .build();
         // when
         when(popupStoreRepository.findByIdAndEndDateAfter(popupStoreId, LocalDate.now())).thenReturn(Optional.ofNullable(popupStore));
         when(promotionEventRepository.save(any())).thenReturn(promotionEvent);
-        PromotionEventCreateResponseDto responseDto = promotionEventService.createEvent(requestDto, popupStoreId);
+        PromotionEventCreateResponseDto responseDto = promotionEventService.createEvent(requestDto);
 
         // then
         assertEquals(popupStoreId, responseDto.getPopupStoreId());
@@ -91,6 +93,7 @@ class PromotionEventServiceTest {
         // given
         Long popupStoreId = 1L;
         PromotionEventCreateRequestDto requestDto = PromotionEventCreateRequestDto.builder()
+                .popupStoreId(popupStoreId)
                 .endDateTime(LocalDateTime.now().plusDays(2))
                 .build();
         PopupStore popupStore = PopupStore.builder()
@@ -100,7 +103,7 @@ class PromotionEventServiceTest {
         // when
         when(popupStoreRepository.findByIdAndEndDateAfter(popupStoreId, LocalDate.now())).thenReturn(Optional.ofNullable(popupStore));
         Throwable exception = assertThrows(CustomApiException.class, ()->
-                promotionEventService.createEvent(requestDto, popupStoreId));
+                promotionEventService.createEvent(requestDto));
         // then
         assertEquals("이벤트 종료일은 팝업스토어 종료일 이후로 선택할 수 없습니다.", exception.getMessage());
     }


### PR DESCRIPTION
이벤트 엔티티에 manyToOne으로 팝업과 연관관계 맺어져 있던 것 해제 후 서비스 로직 변경 현재 findById.orElse(null) 로 해뒀는데
특정 팝업의 이벤트인데 이벤트 조회시에 해당 팝업이 특정이유로 삭제되었을 경우엔 findById 했을 때 orElse 로 가버릴 텐데 이 경우에 null 로 반환하여 알수없는 팝업 이라고 띄워주게 하면 될지 아니면 예외를 던지는게 더 나을지 의견주시면 감사하겠습니다.