### PR TITLE
[#275] fix : cd 파일 수정 및 테스트용 스케줄드 삭제

### DIFF
--- a/.github/workflows/merge-cd.yml
+++ b/.github/workflows/merge-cd.yml
@@ -34,8 +34,16 @@ jobs:
 
       # Spring boot application 빌드
       - name: Build with gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test
 
+      # Docker Hub에 이미지 push 하기
+      - name: Docker build
+        run: |
+         docker login -u ${{ secrets.DOCKER_USER_NAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+         docker build -t ${{ secrets.DOCKER_USER_NAME }}/spot-on . 
+         docker push ${{ secrets.DOCKER_USER_NAME }}/spot-on
+
+      # 기존 애플리케이션 이미지 삭제 후 최신 이미지 pull 과 docker-compose.yml 최신화를 위한 git pull orgin dev
       - name: SSH into EC2 and pull latest code
         uses: appleboy/ssh-action@master
         with:
@@ -49,4 +57,7 @@ jobs:
             git pull origin dev
             # Docker Compose 실행
             docker-compose down
+            if [ "$(docker images -q ${{ secrets.DOCKER_USER_NAME}}/spot-on:latest)" ]; then
+              docker rmi -f ${{ secrets.DOCKER_USER_NAME}}/spot-on:latest
+            fi
             docker-compose up -d

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/repository/PromotionEventRepository.java
@@ -4,26 +4,12 @@ import com.sparta.popupstore.domain.promotionevent.entity.PromotionEvent;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PromotionEventRepository extends JpaRepository<PromotionEvent, Long> {
-//    @Modifying
-//    @Query("update PromotionEvent p set p.deletedAt = now() where p.id = :promotionEventId")
-//    void deletePromotionEvent(@Param("promotionEventId") Long promotionEventId);
-
-//    @Query(value = "select * from events e where timestampdiff(month , e.end_date_time, now()) >= 6", nativeQuery = true)
-//    List<PromotionEvent> findAllByEndDateTimeAfterSixMonths();
-
-    // 추후 스케줄러에 사용될 수 있음.
-    @Modifying
-    @Query("update PromotionEvent p set p.couponGetCount = p.couponGetCount + 1 where p.id = :promotionEventId")
-    void couponGetCountUp(@Param("promotionEventId") Long promotionEventId);
-
     // 프로모션 이벤트 쿠폰 발급 동시성 제어 비관적 락 사용
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from PromotionEvent p where p.id = :promotionEventId")

--- a/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
+++ b/src/main/java/com/sparta/popupstore/domain/promotionevent/scheduler/PromotionEventEndCouponDeleteScheduler.java
@@ -20,7 +20,6 @@ public class PromotionEventEndCouponDeleteScheduler {
     private final CouponRepository couponRepository;
 
     @Transactional
-    @Scheduled(fixedRate = 300000) // 테스트 용
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 00시 00분
     public void hardDeletePromotionEvent() {
         log.info("hardDeletePromotionEvent 스케줄러 시작");
@@ -31,7 +30,6 @@ public class PromotionEventEndCouponDeleteScheduler {
     }
 
     @Transactional
-    @Scheduled(fixedRate = 300000, zone = "Asia/Seoul") // 테스트 용
     @Scheduled(cron = "0 0 0 * * *") // 매일 00시 00분
     public void softDeleteCoupon() {
         log.info("softDeleteCoupon 스케줄러 시작");

--- a/src/main/java/com/sparta/popupstore/s3/scheduler/S3Scheduler.java
+++ b/src/main/java/com/sparta/popupstore/s3/scheduler/S3Scheduler.java
@@ -25,7 +25,6 @@ public class S3Scheduler {
     private final S3ImageService s3ImageService;
     private static final boolean RECURSIVE = true;
 
-    @Scheduled(fixedRate = 500000000)
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void s3ReviewImageDelete(){
         log.info("s3 Review 쓰이지 않는 이미지 삭제 스케줄러 실행");
@@ -37,7 +36,6 @@ public class S3Scheduler {
         log.info("s3 Review 쓰이지 않는 이미지 삭제 스케줄러 종료");
     }
 
-    @Scheduled(fixedRate = 500000000)
     @Scheduled(cron = "0 30 2 * * *", zone = "Asia/Seoul")
     public void s3PromotionEventImageDelete(){
         log.info("s3 PromotionEvent 쓰이지 않는 이미지 삭제 스케줄러 실행");
@@ -49,7 +47,6 @@ public class S3Scheduler {
         log.info("s3 PromotionEvent 쓰이지 않는 이미지 삭제 스케줄러 종료");
     }
 
-    @Scheduled(fixedRate = 500000000)
     @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
     public void s3PopupStoreImageDelete(){
         log.info("s3 PopupStore 쓰이지 않는 이미지 삭제 스케줄러 실행");


### PR DESCRIPTION
레퍼지토리 쓰지않는 메서드 삭제 및 스케줄러 테스트용으로 달아둔 스케줄드 삭제

cd 파일은 도커허브 저장소의 이미지를 최신화 해야지
이미지를 pull 받을 때 최신 애플리케이션정보가 들어있는 이미지를 받아올 수 있습니다.
git pull 을 해서 실행하더라도 docker-compose 에서 결국 이미지로 실행을 하기 때문에 그때그때 도커허브 저장소에도 최신 이미지를 빌드 후 이미지 pull 받는 식으로 해야합니다. 저희가 docker-compose 로 모든 컨테이너를 하나의 서버에서 같이 띄우기 때문에 이렇게 했습니다.